### PR TITLE
Update BatchHighlighterColors.java

### DIFF
--- a/src/org/intellij/lang/batch/editor/BatchHighlighterColors.java
+++ b/src/org/intellij/lang/batch/editor/BatchHighlighterColors.java
@@ -44,7 +44,7 @@ public interface BatchHighlighterColors {
         "BATCH.BRACES", DefaultLanguageHighlighterColors.BRACES
     );
     TextAttributesKey BRACKETS = TextAttributesKey.createTextAttributesKey(
-        "BATCH.BRACES", DefaultLanguageHighlighterColors.BRACKETS
+        "BATCH.BRACKETS", DefaultLanguageHighlighterColors.BRACKETS
     );
     TextAttributesKey PARENTHS = TextAttributesKey.createTextAttributesKey(
         "BATCH.PARENTHS", DefaultLanguageHighlighterColors.PARENTHESES


### PR DESCRIPTION
TextAttributeKey for BRACES was being registered twice. Should fix #30 and fix #29 