### PR TITLE
Going generic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+// see https://github.com/JetBrains/gradle-intellij-plugin/
+
 plugins {
     id 'java'
     id 'org.jetbrains.intellij' version '0.4.10'
@@ -15,11 +17,12 @@ dependencies {
 
 intellij {
     version '2019.2'
-    //IntelliJ IDEA 2016.3 dependency; for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
+    // IntelliJ IDEA 2016.3 dependency; for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     pluginName 'idea-batch'
 }
 
 patchPluginXml {
+    untilBuild ''
     changeNotes """
                <b>Changes in version 1.0.7:</b>
                <ul>
@@ -43,4 +46,4 @@ patchPluginXml {
 }
 
 group 'org.intellij.lang.batch'
-version '1.0.10'
+version '1.0.11'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,8 @@
     </description>
 
     <category>Custom Languages</category>
-    <idea-version since-build="191.4212.41"/>
+
+    <depends>com.intellij.modules.platform</depends>
 
     <resource-bundle>i18n.BatchBundle</resource-bundle>
 


### PR DESCRIPTION
1. made untilBuild none. reasoning: Jetbrains plugin API does not change a lot, no need to rebuild batch plugin for every IDEA version

2. added dependency on com.intellij.modules.platform, this should allow batch plugin to be loaded to other IDE, like CLion or PyCharm