### PR TITLE
Resolve paths inside base project dir dynamically

### DIFF
--- a/src/main/java/org/intellij/lang/batch/runner/BatchRunConfiguration.java
+++ b/src/main/java/org/intellij/lang/batch/runner/BatchRunConfiguration.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author wibotwi
@@ -98,9 +100,21 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
     public void readExternal(@NotNull Element element) throws InvalidDataException {
         super.readExternal(element);
 
+        // project base path
+        String base = getProject().getBasePath() + "/";
+        if (!base.endsWith("/")) {
+            base += "/";
+        }
         // common config
         interpreterOptions = JDOMExternalizerUtil.readField(element, "INTERPRETER_OPTIONS");
         workingDirectory = JDOMExternalizerUtil.readField(element, "WORKING_DIRECTORY");
+        // validate working directory
+        workingDirectory = workingDirectory.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
+        if (workingDirectory.startsWith("./")) {
+            workingDirectory = workingDirectory.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+        }
+
+        // env vars
         String str = JDOMExternalizerUtil.readField(element, "PARENT_ENVS");
         if (str != null) {
             passParentEnvs = Boolean.parseBoolean(str);
@@ -112,6 +126,13 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
 
         // run config
         scriptName = JDOMExternalizerUtil.readField(element, "SCRIPT_NAME");
+        // validate script name in use case that working directory is not set
+        scriptName = scriptName.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
+        if (scriptName.startsWith("./")) {
+            scriptName = scriptName.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+        }
+
+        // script params
         scriptParameters = JDOMExternalizerUtil.readField(element, "PARAMETERS");
     }
 
@@ -119,9 +140,31 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
     public void writeExternal(@NotNull Element element) throws WriteExternalException {
         super.writeExternal(element);
 
+        // localize paths to project
+        String base = getProject().getBasePath();
+        String localPath = "./";
+        String localWorkingDirectory;
+        String localScriptName;
+
+        if (!base.endsWith("/")) {
+            base += "/";
+        }
+
+        if (workingDirectory.startsWith(base)) {
+            localWorkingDirectory = workingDirectory.replaceFirst(Pattern.quote(base), Matcher.quoteReplacement(localPath));
+        } else {
+            localWorkingDirectory = workingDirectory;
+        }
+
+        if (scriptName.startsWith(base)) {
+            localScriptName = scriptName.replaceFirst(Pattern.quote(base), Matcher.quoteReplacement(localPath));
+        } else {
+            localScriptName = scriptName;
+        }
+
         // common config
         JDOMExternalizerUtil.writeField(element, "INTERPRETER_OPTIONS", interpreterOptions);
-        JDOMExternalizerUtil.writeField(element, "WORKING_DIRECTORY", workingDirectory);
+        JDOMExternalizerUtil.writeField(element, "WORKING_DIRECTORY", localWorkingDirectory);
         JDOMExternalizerUtil.writeField(element, "PARENT_ENVS", Boolean.toString(passParentEnvs));
         EnvironmentVariablesComponent.writeExternal(element, envs);
 
@@ -129,7 +172,7 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
         getConfigurationModule().writeExternal(element);
 
         // run config
-        JDOMExternalizerUtil.writeField(element, "SCRIPT_NAME", scriptName);
+        JDOMExternalizerUtil.writeField(element, "SCRIPT_NAME", localScriptName);
         JDOMExternalizerUtil.writeField(element, "PARAMETERS", scriptParameters);
     }
 

--- a/src/main/java/org/intellij/lang/batch/runner/BatchRunConfiguration.java
+++ b/src/main/java/org/intellij/lang/batch/runner/BatchRunConfiguration.java
@@ -109,9 +109,11 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
         interpreterOptions = JDOMExternalizerUtil.readField(element, "INTERPRETER_OPTIONS");
         workingDirectory = JDOMExternalizerUtil.readField(element, "WORKING_DIRECTORY");
         // validate working directory
-        workingDirectory = workingDirectory.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
-        if (workingDirectory.startsWith("./")) {
-            workingDirectory = workingDirectory.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+        if (workingDirectory != null) {
+            workingDirectory = workingDirectory.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
+            if (workingDirectory.startsWith("./")) {
+                workingDirectory = workingDirectory.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+            }
         }
 
         // env vars
@@ -127,11 +129,12 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
         // run config
         scriptName = JDOMExternalizerUtil.readField(element, "SCRIPT_NAME");
         // validate script name in use case that working directory is not set
-        scriptName = scriptName.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
-        if (scriptName.startsWith("./")) {
-            scriptName = scriptName.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+        if (scriptName != null) {
+            scriptName = scriptName.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("/"));
+            if (scriptName.startsWith("./")) {
+                scriptName = scriptName.replaceFirst(Pattern.quote("./"), Matcher.quoteReplacement(base));
+            }
         }
-
         // script params
         scriptParameters = JDOMExternalizerUtil.readField(element, "PARAMETERS");
     }
@@ -150,13 +153,13 @@ public class BatchRunConfiguration extends ModuleBasedConfiguration<RunConfigura
             base += "/";
         }
 
-        if (workingDirectory.startsWith(base)) {
+        if (workingDirectory != null && workingDirectory.startsWith(base)) {
             localWorkingDirectory = workingDirectory.replaceFirst(Pattern.quote(base), Matcher.quoteReplacement(localPath));
         } else {
             localWorkingDirectory = workingDirectory;
         }
 
-        if (scriptName.startsWith(base)) {
+        if (scriptName != null && scriptName.startsWith(base)) {
             localScriptName = scriptName.replaceFirst(Pattern.quote(base), Matcher.quoteReplacement(localPath));
         } else {
             localScriptName = scriptName;


### PR DESCRIPTION
This allows scripts that are in the project directory to be dynamically resolved when the run configurations are loaded. 

Existing configurations do not need any modification. Configurations will show absolute path like they previously have. Any path within the project base directory will be localized to the project path when the configuration is saved, then resolved to the project when the configuration is loaded. 

This allows for run configurations to be portable between multiple developers using VCS option in the run configuration. 

I have done testing on Windows, but can others please test and verify that it works on other platforms, and perform general testing to ensure it works as intended. 

Thank you,
Trevor Flynn